### PR TITLE
cd stack && ./update-global-hints.hs ghc-8.8.2

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -65,6 +65,41 @@ ghc-8.0.1:
   pretty: 1.1.3.3
   template-haskell: 2.11.0.0
   directory: 1.2.6.2
+ghc-8.8.2:
+  ghc: 8.8.2
+  bytestring: 0.10.10.0
+  unix: 2.7.2.2
+  haskeline: 0.7.5.0
+  stm: 2.5.0.0
+  Cabal: 3.0.1.0
+  base: 4.13.0.0
+  time: 1.9.3
+  xhtml: 3000.2.2.1
+  text: 1.2.4.0
+  hpc: 0.6.0.3
+  filepath: 1.4.2.1
+  process: 1.6.7.0
+  parsec: 3.1.14.0
+  ghc-compact: 0.1.0.0
+  array: 0.5.4.0
+  Win32: 2.6.1.0
+  integer-gmp: 1.0.2.0
+  containers: 0.6.2.1
+  libiserv: 8.8.2
+  ghc-boot: 8.8.2
+  binary: 0.8.7.0
+  ghc-prim: 0.5.3
+  mtl: 2.2.2
+  ghc-heap: 8.8.2
+  ghci: 8.8.2
+  rts: '1.0'
+  terminfo: 0.4.1.4
+  transformers: 0.5.6.2
+  deepseq: 1.4.4.0
+  ghc-boot-th: 8.8.2
+  pretty: 1.1.3.6
+  template-haskell: 2.15.0.0
+  directory: 1.3.4.0
 ghc-8.2.2:
   ghc: 8.2.2
   hoopl: 3.10.2.2


### PR DESCRIPTION
I don't know if stack still uses these hint files but I'm assuming that it does.