### PR TITLE
Update stack-setup-2.yaml for msys2-20220503 release (x86_64 only)

### DIFF
--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -69,7 +69,7 @@ portable-git:
     content-length: 44221160
     sha1: 3df088915f67297cb5ad3ab73ba9361fcb5e44ea
 
-# For upgrade instructions, see: https://github.com/commercialhaskell/stack/blob/stable/doc/MAINTAINER_GUIDE.md#upgrading-msys
+# For upgrade instructions, see: https://github.com/commercialhaskell/stack/blob/stable/doc/maintainers/msys.md
 msys2:
     windows32:
         version: "20200517"
@@ -77,10 +77,10 @@ msys2:
         content-length: 79049224
         sha256: 9152ddf50c6bacfae33c1436338235f8db4b10d73aaea63adefd96731fb0bceb
     windows64:
-        version: "20210604"
-        url: "https://github.com/commercialhaskell/stackage-content/releases/download/msys2-20210604/msys2-20210604-x86_64.tar.xz"
-        content-length: 99822772
-        sha256: 754afa315584afb601a275e658151ce2eaab7822a0da70791bbe31e26927dde2
+        version: "20220503"
+        url: "https://github.com/commercialhaskell/stackage-content/releases/download/msys2-20220503/msys2-20220503-x86_64.tar.xz"
+        content-length: 93835868
+        sha256: C918F66E984F70ADD313EE3A5C5B101132CD93D5A3F8E3555E129E2D3DCB3718
 ghc:
 
     linux32:

--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -80,7 +80,7 @@ msys2:
         version: "20220503"
         url: "https://github.com/commercialhaskell/stackage-content/releases/download/msys2-20220503/msys2-20220503-x86_64.tar.xz"
         content-length: 93835868
-        sha256: C918F66E984F70ADD313EE3A5C5B101132CD93D5A3F8E3555E129E2D3DCB3718
+        sha256: c918f66e984f70add313ee3a5c5b101132cd93d5a3f8e3555e129e2d3dcb3718
 ghc:
 
     linux32:


### PR DESCRIPTION
I think I have followed the instructions faithfully, but I am not sure how to 'test this file locally first'. On PowerShell, I took the `content-length` from the `Length` field of `dir`. I took the `sha256` from the output of:
~~~
❯ Get-FileHash msys2-20220503-x86_64.tar.xz -Algorithm SHA256 | Format-List -Property Hash
~~~