### PR TITLE
Fix #135 Add GHC 9.2.6 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -1089,6 +1089,43 @@ ghc-9.2.5:
   transformers: 0.5.6.2
   unix: 2.7.2.2
   xhtml: 3000.2.2.1
+ghc-9.2.6:
+  Cabal: 3.6.3.0
+  Win32: 2.12.0.1
+  array: 0.5.4.0
+  base: 4.16.4.0
+  binary: 0.8.9.0
+  bytestring: 0.11.4.0
+  containers: 0.6.5.1
+  deepseq: 1.4.6.1
+  directory: 1.3.6.2
+  exceptions: 0.10.4
+  filepath: 1.4.2.2
+  ghc: 9.2.6
+  ghc-bignum: '1.2'
+  ghc-boot: 9.2.6
+  ghc-boot-th: 9.2.6
+  ghc-compact: 0.1.0.0
+  ghc-heap: 9.2.6
+  ghc-prim: 0.8.0
+  ghci: 9.2.6
+  haskeline: 0.8.2
+  hpc: 0.6.1.0
+  integer-gmp: '1.1'
+  libiserv: 9.2.6
+  mtl: 2.2.2
+  parsec: 3.1.15.0
+  pretty: 1.1.3.6
+  process: 1.6.16.0
+  rts: 1.0.2
+  stm: 2.5.0.2
+  template-haskell: 2.18.0.0
+  terminfo: 0.4.1.5
+  text: 1.2.5.0
+  time: 1.11.1.1
+  transformers: 0.5.6.2
+  unix: 2.7.2.2
+  xhtml: 3000.2.2.1
 ghc-8.10.6:
   exceptions: 0.10.4
   ghc: 8.10.6


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.5` and `unix-2.7.2.2`. Also compared with https://downloads.haskell.org/~ghc/9.2.6/docs/html/users_guide/9.2.6-notes.html#included-libraries.