### PR TITLE
Fix #150 Add GHC 9.6.2 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -1532,3 +1532,42 @@ ghc-9.6.1:
   transformers: 0.6.1.0
   unix: 2.8.1.0
   xhtml: 3000.2.2.1
+ghc-9.6.2:
+  Cabal: 3.10.1.0
+  Cabal-syntax: 3.10.1.0
+  Win32: 2.13.3.0
+  array: 0.5.5.0
+  base: 4.18.0.0
+  binary: 0.8.9.1
+  bytestring: 0.11.4.0
+  containers: 0.6.7
+  deepseq: 1.4.8.1
+  directory: 1.3.8.1
+  exceptions: 0.10.7
+  filepath: 1.4.100.1
+  ghc: 9.6.2
+  ghc-bignum: '1.3'
+  ghc-boot: 9.6.2
+  ghc-boot-th: 9.6.2
+  ghc-compact: 0.1.0.0
+  ghc-heap: 9.6.2
+  ghc-prim: 0.10.0
+  ghci: 9.6.2
+  haskeline: 0.8.2.1
+  hpc: 0.6.2.0
+  integer-gmp: '1.1'
+  libiserv: 9.6.2
+  mtl: 2.3.1
+  parsec: 3.1.16.1
+  pretty: 1.1.3.6
+  process: 1.6.17.0
+  rts: 1.0.2
+  stm: 2.5.1.0
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.20.0.0
+  terminfo: 0.4.1.6
+  text: 2.0.2
+  time: 1.12.2
+  transformers: 0.6.1.0
+  unix: 2.8.1.0
+  xhtml: 3000.2.2.1


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.6` and `unix-2.8.1.0` taken from https://downloads.haskell.org/ghc/9.6.2/docs/users_guide/9.6.2-notes.html#included-libraries.