### PR TITLE
Fix #162 Add GHC 9.4.6 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -1530,6 +1530,45 @@ ghc-9.4.5:
   transformers: 0.5.6.2
   unix: 2.7.3
   xhtml: 3000.2.2.1
+ghc-9.4.6:
+  Cabal: 3.8.1.0
+  Cabal-syntax: 3.8.1.0
+  Win32: 2.12.0.1
+  array: 0.5.4.0
+  base: 4.17.2.0
+  binary: 0.8.9.1
+  bytestring: 0.11.5.1
+  containers: 0.6.7
+  deepseq: 1.4.8.0
+  directory: 1.3.7.1
+  exceptions: 0.10.5
+  filepath: 1.4.2.2
+  ghc: 9.4.6
+  ghc-bignum: '1.3'
+  ghc-boot: 9.4.6
+  ghc-boot-th: 9.4.6
+  ghc-compact: 0.1.0.0
+  ghc-heap: 9.4.6
+  ghc-prim: 0.9.1
+  ghci: 9.4.6
+  haskeline: 0.8.2
+  hpc: 0.6.1.0
+  integer-gmp: '1.1'
+  libiserv: 9.4.6
+  mtl: 2.2.2
+  parsec: 3.1.16.1
+  pretty: 1.1.3.6
+  process: 1.6.17.0
+  rts: 1.0.2
+  stm: 2.5.1.0
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.19.0.0
+  terminfo: 0.4.1.5
+  text: 2.0.2
+  time: 1.12.2
+  transformers: 0.5.6.2
+  unix: 2.7.3
+  xhtml: 3000.2.2.1
 ghc-9.6.1:
   Cabal: 3.10.1.0
   Cabal-syntax: 3.10.1.0


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.5` and `unix-2.7.3` taken from https://downloads.haskell.org/ghc/9.4.6/docs/users_guide/9.4.6-notes.html#included-libraries.

