### PR TITLE
Fix #175 Add GHC 9.8.1 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -1725,3 +1725,42 @@ ghc-9.6.3:
   transformers: 0.6.1.0
   unix: 2.8.1.0
   xhtml: 3000.2.2.1
+ghc-9.8.1:
+  Cabal: 3.10.2.0
+  Cabal-syntax: 3.10.2.0
+  Win32: 2.13.4.0
+  array: 0.5.6.0
+  base: 4.19.0.0
+  binary: 0.8.9.1
+  bytestring: 0.12.0.2
+  containers: 0.6.8
+  deepseq: 1.5.0.0
+  directory: 1.3.8.1
+  exceptions: 0.10.7
+  filepath: 1.4.100.4
+  ghc: 9.8.1
+  ghc-bignum: '1.3'
+  ghc-boot: 9.8.1
+  ghc-boot-th: 9.8.1
+  ghc-compact: 0.1.0.0
+  ghc-heap: 9.8.1
+  ghc-prim: 0.11.0
+  ghci: 9.8.1
+  haskeline: 0.8.2.1
+  hpc: 0.7.0.0
+  integer-gmp: '1.1'
+  mtl: 2.3.1
+  parsec: 3.1.17.0
+  pretty: 1.1.3.6
+  process: 1.6.18.0
+  rts: 1.0.2
+  semaphore-compat: 1.0.0
+  stm: 2.5.2.1
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.21.0.0
+  terminfo: 0.4.1.6
+  text: 2.1
+  time: 1.12.2
+  transformers: 0.6.1.0
+  unix: 2.8.3.0
+  xhtml: 3000.2.2.1


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.6` and `unix-2.8.3.0` taken from https://downloads.haskell.org/~ghc/9.8.1/docs/users_guide/9.8.1-notes.html#included-libraries.