### PR TITLE
fix content-length for 9.8.2 on linux64-tinfo6

### DIFF
--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -1503,7 +1503,7 @@ ghc:
             sha256: dd21379f9d2dfd27817adba94ac1209c03e1c40acc3f499eac94e245a56b5dc6
         9.8.2:
             url: "https://downloads.haskell.org/ghc/9.8.2/ghc-9.8.2-x86_64-fedora33-linux.tar.xz"
-            content-length:  214363160
+            content-length:  213956760
             sha1: ab5afb49b6f63bc6f40c18336770d9c71f585cd0
             sha256: 99639e49179664cf69f533d00ab30da5f7333370a9b9d3c750453a1e51be4f29
 


### PR DESCRIPTION
Here's how I reproduced the issue:

```
$ docker run -it --entrypoint=/bin/bash ghcr.io/commercialhaskell/stackage/build:nightly
root@190222c36ed8:/# GHCVER=9.8.2
root@190222c36ed8:/# STACK_VERSION=2.15.3
root@190222c36ed8:/# curl -L https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64-bin > stack
root@190222c36ed8:/# chmod +x stack
root@190222c36ed8:/# ./stack setup ghc-$GHCVER
Writing the configuration file for the implicit global project to:
/home/stackage/.stack/global-project/stack.yaml. Note: You can
change the snapshot via the resolver field there.
Using the latest snapshot lts-22.11.
Preparing to install GHC (tinfo6) to an isolated location. This
will not interfere with any system-level installation.
Preparing to download ghc-tinfo6-9.8.2 ...
Download expectation failure: ContentLength header
Expected: 214363160
Actual:   213956760
For: https://downloads.haskell.org/ghc/9.8.2/ghc-9.8.2-x86_64-fedora33-linux.tar.xz
```

I manually downloaded and checked the xz and it matches the expected shas. The actual length is as it says, which does not match the expectations currently listed in `stack-setup-2.yaml`.