### PR TITLE
Fix #218 Add GHC 9.12.1 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -2081,3 +2081,50 @@ ghc-9.10.1:
   transformers: 0.6.1.1
   unix: 2.8.5.1
   xhtml: 3000.2.2.1
+ghc-9.12.1:
+  Cabal: 3.14.1.0
+  Cabal-syntax: 3.14.1.0
+  Win32: 2.14.1.0
+  array: 0.5.8.0
+  base: 4.21.0.0
+  binary: 0.8.9.2
+  bytestring: 0.12.2.0
+  containers: '0.7'
+  deepseq: 1.5.1.0
+  directory: 1.3.9.0
+  exceptions: 0.10.9
+  file-io: 0.1.5
+  filepath: 1.5.4.0
+  ghc: 9.12.1
+  ghc-bignum: '1.3'
+  ghc-boot: 9.12.1
+  ghc-boot-th: 9.12.1
+  ghc-compact: 0.1.0.0
+  ghc-experimental: 9.1201.0
+  ghc-heap: 9.12.1
+  ghc-internal: 9.1201.0
+  ghc-platform: 0.1.0.0
+  ghc-prim: 0.13.0
+  ghc-toolchain: 0.1.0.0
+  ghci: 9.12.1
+  haddock-api: 2.30.0
+  haddock-library: 1.11.0
+  haskeline: 0.8.2.1
+  hpc: 0.7.0.1
+  integer-gmp: '1.1'
+  mtl: 2.3.1
+  os-string: 2.0.7
+  parsec: 3.1.17.0
+  pretty: 1.1.3.6
+  process: 1.6.25.0
+  rts: 1.0.2
+  semaphore-compat: 1.0.0
+  stm: 2.5.3.1
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.23.0.0
+  terminfo: 0.4.1.6
+  text: 2.1.2
+  time: '1.14'
+  transformers: 0.6.1.2
+  unix: 2.8.6.0
+  xhtml: 3000.2.2.1


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.6` and `unix-2.8.6.0` taken from https://downloads.haskell.org/ghc/9.12.1/docs/users_guide/9.12.1-notes.html#included-libraries.

The new boot packages: `file-io`, `haddock-api` and `haddock-library` have been included.