### PR TITLE
Fix #233 Add GHC 9.10.2 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -2120,6 +2120,50 @@ ghc-9.10.1:
   transformers: 0.6.1.1
   unix: 2.8.5.1
   xhtml: 3000.2.2.1
+ghc-9.10.2:
+  Cabal: 3.12.1.0
+  Cabal-syntax: 3.12.1.0
+  Win32: 2.14.1.0
+  array: 0.5.8.0
+  base: 4.20.1.0
+  binary: 0.8.9.3
+  bytestring: 0.12.2.0
+  containers: '0.7'
+  deepseq: 1.5.0.0
+  directory: 1.3.8.5
+  exceptions: 0.10.9
+  filepath: 1.5.4.0
+  ghc: 9.10.2
+  ghc-bignum: '1.3'
+  ghc-boot: 9.10.2
+  ghc-boot-th: 9.10.2
+  ghc-compact: 0.1.0.0
+  ghc-experimental: 9.1002.0
+  ghc-heap: 9.10.2
+  ghc-internal: 9.1002.0
+  ghc-platform: 0.1.0.0
+  ghc-prim: 0.12.0
+  ghc-toolchain: 0.1.0.0
+  ghci: 9.10.2
+  haskeline: 0.8.2.1
+  hpc: 0.7.0.2
+  integer-gmp: '1.1'
+  mtl: 2.3.1
+  os-string: 2.0.4
+  parsec: 3.1.18.0
+  pretty: 1.1.3.6
+  process: 1.6.25.0
+  rts: 1.0.2
+  semaphore-compat: 1.0.0
+  stm: 2.5.3.1
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.22.0.0
+  terminfo: 0.4.1.7
+  text: 2.1.2
+  time: 1.12.2
+  transformers: 0.6.1.1
+  unix: 2.8.6.0
+  xhtml: 3000.2.2.1
 ghc-9.12.1:
   Cabal: 3.14.1.0
   Cabal-syntax: 3.14.1.0


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.7` and `unix-2.8.6.0` taken from https://downloads.haskell.org/ghc/9.10.2/docs/users_guide/9.10.2-notes.html#included-libraries.