### PR TITLE
Fix #239 Add GHC 9.10.3 global hints

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -2164,6 +2164,50 @@ ghc-9.10.2:
   transformers: 0.6.1.1
   unix: 2.8.6.0
   xhtml: 3000.2.2.1
+ghc-9.10.3:
+  Cabal: 3.12.1.0
+  Cabal-syntax: 3.12.1.0
+  Win32: 2.14.1.0
+  array: 0.5.8.0
+  base: 4.20.2.0
+  binary: 0.8.9.3
+  bytestring: 0.12.2.0
+  containers: '0.7'
+  deepseq: 1.5.0.0
+  directory: 1.3.8.5
+  exceptions: 0.10.9
+  filepath: 1.5.4.0
+  ghc: 9.10.3
+  ghc-bignum: '1.3'
+  ghc-boot: 9.10.3
+  ghc-boot-th: 9.10.3
+  ghc-compact: 0.1.0.0
+  ghc-experimental: 9.1003.0
+  ghc-heap: 9.10.3
+  ghc-internal: 9.1003.0
+  ghc-platform: 0.1.0.0
+  ghc-prim: 0.12.0
+  ghc-toolchain: 0.1.0.0
+  ghci: 9.10.3
+  haskeline: 0.8.2.1
+  hpc: 0.7.0.2
+  integer-gmp: '1.1'
+  mtl: 2.3.1
+  os-string: 2.0.7
+  parsec: 3.1.18.0
+  pretty: 1.1.3.6
+  process: 1.6.26.1
+  rts: 1.0.2
+  semaphore-compat: 1.0.0
+  stm: 2.5.3.1
+  system-cxx-std-lib: '1.0'
+  template-haskell: 2.22.0.0
+  terminfo: 0.4.1.7
+  text: 2.1.3
+  time: 1.12.2
+  transformers: 0.6.1.1
+  unix: 2.8.7.0
+  xhtml: 3000.2.2.1
 ghc-9.12.1:
   Cabal: 3.14.1.0
   Cabal-syntax: 3.14.1.0


### PR DESCRIPTION
Based on `ghc-pkg list` on a Windows system, plus `terminfo-0.4.1.7` and `unix-2.8.7.0` taken from https://downloads.haskell.org/ghc/9.10.3/docs/users_guide/9.10.3-notes.html#included-libraries.